### PR TITLE
Fix columns selection in 'printEnrich'

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -99,4 +99,13 @@ Plot Enrichr GO-BP output. (Plotting function contributed by I-Hsuan Lin)
 plotEnrich(enriched[[3]], showTerms = 20, numChar = 40, y = "Count", orderBy = "P.value")
 ```
 
+Save Enrichr results as text or Excel files. By default (i.e. `outFile="txt"`), the results from the
+selected databases are saved into individual text files. When using `outFile="excel"`, the results are
+saved into worksheets in a single Excel 2007 (XLSX) file. (Print function contributed by I-Hsuan Lin
+and Kai Hu)
+
+```{r, echo = TRUE, eval = FALSE}
+printEnrich(enriched)
+```
+
 # References

--- a/README.md
+++ b/README.md
@@ -117,7 +117,16 @@ plotEnrich(enriched[[3]], showTerms = 20, numChar = 40, y = "Count", orderBy = "
 
 <img src="./tools/README-unnamed-chunk-12-1.png" style="display: block; margin: auto;" />
 
-# References2
+Save Enrichr results as text or Excel files. By default (i.e. `outFile="txt"`), the results from the
+selected databases are saved into individual text files. When using `outFile="excel"`, the results are
+saved into worksheets in a single Excel 2007 (XLSX) file. (Print function contributed by I-Hsuan Lin
+and Kai Hu)
+
+```r
+printEnrich(enriched)
+```
+
+# References
 
 <div id="refs" class="references csl-bib-body hanging-indent">
 

--- a/man/printEnrich.Rd
+++ b/man/printEnrich.Rd
@@ -9,8 +9,8 @@ printEnrich(
   prefix = "enrichr",
   showTerms = NULL,
   columns = c(1:9),
-  write2file = TRUE,
-  outFile = c("txt", "excel")
+  outFile = c("txt", "excel"),
+  write2file = NULL
 )
 }
 \arguments{
@@ -21,21 +21,22 @@ printEnrich(
 \item{showTerms}{(Optional). Number of terms to show.
 Default is \code{NULL} to print all terms.}
 
-\item{columns}{(Optional). Columns from each entry of data.
-Default is \code{c(1:9)} to print all columns.
+\item{columns}{(Optional). Columns from each entry of data, denoted by a positive 
+integer vector. Default is \code{c(1:9)} to print all columns.
 1-"Term", 2-"Overlap", 3-"P.value", 4-"Adjusted.P.value" 5-"Old.P.value",
 6-"Old.Adjusted.P.value" 7-"Odds.Ratio" 8-"Combined.Score" 9-"Combined.Score"}
 
-\item{write2file}{(Optional). Set to TRUE if you would like this functino to
-output a file}
+\item{outFile}{(Optional). Output file format, choose from "txt" and "excel". 
+Default is "txt".}
 
-\item{outFile}{(Optional). Output file format, choose from "txt" and "excel". Default is "txt".}
+\item{write2file}{(Optional). Deprecated argument. Always print to text or Excel file(s).}
 }
 \description{
 Print Enrichr results
 }
 \details{
-Print Enrichr results from the selected gene-set libraries to individual text files.
+Print Enrichr results from the selected gene-set libraries to individual text files 
+or a Excel spreadsheet.
 }
 \examples{
 if (getOption("enrichR.live")) {
@@ -45,7 +46,7 @@ if (getOption("enrichR.live")) {
   dbs <- c("GO_Molecular_Function_2018", "GO_Cellular_Component_2018",
            "GO_Biological_Process_2018")
   enriched <- enrichr(c("Runx1", "Gfi1", "Gfi1b", "Spi1", "Gata1", "Kdr"), dbs)
-  if (enrichRLive) printEnrich(enriched, write2file = FALSE)
+  if (enrichRLive) printEnrich(enriched, outFile = "excel")
 }
 }
 \author{

--- a/vignettes/enrichR.Rmd
+++ b/vignettes/enrichR.Rmd
@@ -98,4 +98,13 @@ if (websiteLive) {
 }
 ```
 
+Save Enrichr results as text or Excel files. By default (i.e. `outFile="txt"`), the results from the 
+selected databases are saved into individual text files. When using `outFile="excel"`, the results are
+saved into worksheets in a single Excel 2007 (XLSX) file. (Print function contributed by I-Hsuan Lin
+and Kai Hu)
+
+```{r, echo = TRUE, eval = FALSE}
+if (websiteLive) printEnrich(enriched)
+```
+
 # References


### PR DESCRIPTION
The PR fixes a bug reported in #65 and made some changes:

- Users can now use the `columns=` argument to subset the enrichR results
- Improve `columns=` description in documentation and error message
- Deprecated `write2file=` as the function always produce outfiles (text or Excel)
- Added `printEnrich` to README and vignettes