### PR TITLE
Fix an error with using '...' in listEnrichrDbs()

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -167,7 +167,7 @@ setEnrichrSite <- function(site) {
 listEnrichrDbs <- function() {
     dfSAF <- getOption("stringsAsFactors", FALSE)
     options(stringsAsFactors = FALSE)
-    dbs <- getEnrichr(url = paste0(getOption("enrichR.base.address"), "datasetStatistics"), ...)
+    dbs <- getEnrichr(url = paste0(getOption("enrichR.base.address"), "datasetStatistics"))
     if (!getOption("enrichR.live")) return()
     dbs <- intToUtf8(dbs$content)
     dbs <- fromJSON(dbs)


### PR DESCRIPTION
This PR fix a bug with `listEnrichrDbs()` reported in #88. 

The `...` was unintentionally added in PR #83 when making enrichR to support connection via proxy.

There was a warning at first when installing the package from source.

```
* installing to library ‘xxx’
* installing *source* package ‘enrichR’ ...
** using staged installation
** R
** data
*** moving datasets to lazyload DB
** byte-compile and prepare package for lazy loading
Note: ... may be used in an incorrect context 
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
```

And when actually running enrichR, the error appears:

```r
library(enrichR)
listEnrichrSites()
listEnrichrDbs()
```

```
Error in getEnrichr(url = paste0(getOption("enrichR.base.address"), "datasetStatistics"),  : 
  '...' used in an incorrect context
```